### PR TITLE
change aioresponses to aiointercept

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ line_length = 79
 lines_between_types = 1
 multi_line_output = 3
 include_trailing_comma = 1
-known_third_party = requests, pytest, aioresponses
+known_third_party = requests, pytest
 
 [testenv:sphinx]
 skip_install = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,0 @@
-import pytest
-
-from aioresponses import aioresponses
-
-
-@pytest.fixture
-def aiohttp_mock():
-    with aioresponses() as mock:
-        yield mock

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-aioresponses
+aiointercept
 pytest
 pytest-asyncio
 pytest-cov

--- a/tests/test_reviews.py
+++ b/tests/test_reviews.py
@@ -309,10 +309,10 @@ def test_get_latest_revision_and_change():
 
 
 @pytest.mark.asyncio
-async def test_get_latest_revision_and_change_async(aiohttp_mock):
-    client = SwarmAsyncClient('http://server/api/v9', 'user', 'password')
+async def test_get_latest_revision_and_change_async(aiointercept_mock):
+    client = SwarmAsyncClient(f'{aiointercept_mock.server_url}/api/v9', 'user', 'password')
 
-    aiohttp_mock.get(
+    aiointercept_mock.get(
         re.compile(r'.*/api/v\d+/reviews/12345'),
         payload={
             'review': {

--- a/tests/test_swarm.py
+++ b/tests/test_swarm.py
@@ -125,17 +125,17 @@ def test_sync_client_retry():
 
 
 @pytest.mark.asyncio
-async def test_async_client(aiohttp_mock):
+async def test_async_client(aiointercept_mock):
     try:
         client = SwarmAsyncClient(
-            'http://server/api/v9',
+            f'{aiointercept_mock.server_url}/api/v9',
             'user',
             'password',
             timeout=10,
         )
 
-        aiohttp_mock.get(
-            'http://server/api/v9/version',
+        aiointercept_mock.get(
+            f'{aiointercept_mock.server_url}/api/v9/version',
             payload=GET_VERSION_DATA,
             status=200,
         )
@@ -147,9 +147,9 @@ async def test_async_client(aiohttp_mock):
 
 
 @pytest.mark.asyncio
-async def test_async_client_retry(aiohttp_mock):
+async def test_async_client_retry(aiointercept_mock):
     client = SwarmAsyncClient(
-        'http://server/api/v9',
+        f'{aiointercept_mock.server_url}/api/v9',
         'user',
         'password',
         retry=dict(
@@ -158,14 +158,14 @@ async def test_async_client_retry(aiohttp_mock):
         )
     )
 
-    aiohttp_mock.get(
-        'http://server/api/v9/version',
+    aiointercept_mock.get(
+        f'{aiointercept_mock.server_url}/api/v9/version',
         payload={'error': 'Server error'},
         status=500,
     )
 
-    aiohttp_mock.get(
-        'http://server/api/v9/version',
+    aiointercept_mock.get(
+        f'{aiointercept_mock.server_url}/api/v9/version',
         payload=GET_VERSION_DATA,
         status=200,
     )
@@ -176,9 +176,9 @@ async def test_async_client_retry(aiohttp_mock):
 
 
 @pytest.mark.asyncio
-async def test_async_client_retry_exception(aiohttp_mock):
+async def test_async_client_retry_exception(aiointercept_mock):
     client = SwarmAsyncClient(
-        'http://server/api/v9',
+        f'{aiointercept_mock.server_url}/api/v9',
         'user',
         'password',
         retry=dict(
@@ -187,8 +187,14 @@ async def test_async_client_retry_exception(aiohttp_mock):
         )
     )
 
-    aiohttp_mock.get('http://server/api/v9/version', exception=aiohttp.ClientError())
-    aiohttp_mock.get('http://server/api/v9/version', exception=aiohttp.ClientError())
+    aiointercept_mock.get(
+        f'{aiointercept_mock.server_url}/api/v9/version',
+        exception=aiohttp.ClientError()
+    )
+    aiointercept_mock.get(
+        f'{aiointercept_mock.server_url}/api/v9/version',
+        exception=aiohttp.ClientError()
+    )
 
     with pytest.raises(SwarmError):
         await client.get_version()


### PR DESCRIPTION
Changed the test library from aioresponses to aiointercept. Aiointercept is a library that of wich I'm the maintainer. It has a API similar to aioresponses but it create a real server and does real request. Aiointercept exposes a pytest fixture similar to aiohttp_mock on this repo, so i replaced that with the autoexported fixture